### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,38 +1,38 @@
 [submodule "third-party/pybind11"]
 	path = third-party/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 [submodule "third-party/Hierarchical-Localization"]
 	path = third-party/Hierarchical-Localization
-	url = git@github.com:cvg/Hierarchical-Localization.git
+	url = https://github.com/cvg/Hierarchical-Localization.git
 [submodule "third-party/JLinkage"]
 	path = third-party/JLinkage
-	url = git@github.com:B1ueber2y/JLinkage.git
+	url = https://github.com/B1ueber2y/JLinkage
 [submodule "third-party/libigl"]
 	path = third-party/libigl
-	url = git@github.com:B1ueber2y/libigl.git
+	url = https://github.com/B1ueber2y/libigl.git
 [submodule "third-party/RansacLib"]
 	path = third-party/RansacLib
-	url = git@github.com:B1ueber2y/RansacLib.git
+	url = https://github.com/B1ueber2y/RansacLib.git
     branch = header-only
 [submodule "third-party/HighFive"]
 	path = third-party/HighFive
-	url = git@github.com:B1ueber2y/HighFive.git
+	url = https://github.com/B1ueber2y/HighFive.git
 [submodule "third-party/pytlsd"]
 	path = third-party/pytlsd
-	url = git@github.com:iago-suarez/pytlsd.git
+	url = https://github.com/iago-suarez/pytlsd.git
 [submodule "third-party/pytlbd"]
 	path = third-party/pytlbd
-	url = git@github.com:iago-suarez/pytlbd.git
+	url = https://github.com/iago-suarez/pytlbd.git
 [submodule "third-party/hawp"]
 	path = third-party/hawp
-	url = git@github.com:cherubicXN/hawp.git
+	url = https://github.com/cherubicXN/hawp.git
 	ignore = dirty
 [submodule "third-party/TP-LSD"]
 	path = third-party/TP-LSD
-	url = git@github.com:rpautrat/TP-LSD.git
+	url = https://github.com/rpautrat/TP-LSD.git
 [submodule "third-party/DeepLSD"]
 	path = third-party/DeepLSD
-	url = git@github.com:cvg/DeepLSD.git
+	url = https://github.com/cvg/DeepLSD.git
 [submodule "third-party/GlueStick"]
 	path = third-party/GlueStick
-	url = git@github.com:cvg/GlueStick.git
+	url = https://github.com/cvg/GlueStick.git


### PR DESCRIPTION
The thing can't be installed in docker container. It asks for git credentials, like A LOT during installation

```
(base) ➜  limap git:(main) git submodule update --init --recursive

Submodule 'third-party/DeepLSD' (git@github.com:cvg/DeepLSD.git) registered for path 'third-party/DeepLSD'
Submodule 'third-party/GlueStick' (git@github.com:cvg/GlueStick.git) registered for path 'third-party/GlueStick'
Submodule 'third-party/Hierarchical-Localization' (git@github.com:cvg/Hierarchical-Localization.git) registered for path 'third-party/Hierarchical-Localization'
Submodule 'third-party/HighFive' (git@github.com:B1ueber2y/HighFive.git) registered for path 'third-party/HighFive'
Submodule 'third-party/JLinkage' (git@github.com:B1ueber2y/JLinkage.git) registered for path 'third-party/JLinkage'
Submodule 'third-party/RansacLib' (git@github.com:B1ueber2y/RansacLib.git) registered for path 'third-party/RansacLib'
Submodule 'third-party/TP-LSD' (git@github.com:rpautrat/TP-LSD.git) registered for path 'third-party/TP-LSD'
Submodule 'third-party/hawp' (git@github.com:cherubicXN/hawp.git) registered for path 'third-party/hawp'
Submodule 'third-party/libigl' (git@github.com:B1ueber2y/libigl.git) registered for path 'third-party/libigl'
Submodule 'third-party/pybind11' (git@github.com:pybind/pybind11.git) registered for path 'third-party/pybind11'
Submodule 'third-party/pytlbd' (git@github.com:iago-suarez/pytlbd.git) registered for path 'third-party/pytlbd'
Submodule 'third-party/pytlsd' (git@github.com:iago-suarez/pytlsd.git) registered for path 'third-party/pytlsd'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/GlueStick'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/HighFive'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/JLinkage'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/RansacLib'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/TP-LSD'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/hawp'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/libigl'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pybind11'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pytlbd'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pytlsd'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Submodule path 'third-party/DeepLSD': checked out '59006b264d05e97856556d3f16ded45bd4dbc286'
Submodule 'line_refinement/pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/DeepLSD/line_refinement/pybind11'
Submodule 'third_party/homography_est' (https://github.com/rpautrat/homography_est.git) registered for path 'third-party/DeepLSD/third_party/homography_est'
Submodule 'third_party/progressive-x' (https://github.com/danini/progressive-x.git) registered for path 'third-party/DeepLSD/third_party/progressive-x'
Submodule 'third_party/pytlbd' (https://github.com/iago-suarez/pytlbd.git) registered for path 'third-party/DeepLSD/third_party/pytlbd'
Submodule 'third_party/pytlsd' (https://github.com/iago-suarez/pytlsd.git) registered for path 'third-party/DeepLSD/third_party/pytlsd'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/line_refinement/pybind11'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/homography_est'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/progressive-x'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/pytlbd'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/pytlsd'...
Submodule path 'third-party/DeepLSD/line_refinement/pybind11': checked out '06003e82b3ff48337b71b310b46c3d8b15ca6d5a'
Submodule path 'third-party/DeepLSD/third_party/homography_est': checked out '30dc1a983db7efe68524ebe23cec3f9124173146'
Submodule 'pybind11' (https://github.com/pybind/pybind11.git) registered for path 'third-party/DeepLSD/third_party/homography_est/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/homography_est/pybind11'...
Submodule path 'third-party/DeepLSD/third_party/homography_est/pybind11': checked out '06003e82b3ff48337b71b310b46c3d8b15ca6d5a'
Submodule path 'third-party/DeepLSD/third_party/progressive-x': checked out 'b6ddb94bb332e21a98903585eb85719c608c1bae'
Submodule 'graph-cut-ransac' (https://github.com/danini/graph-cut-ransac.git) registered for path 'third-party/DeepLSD/third_party/progressive-x/graph-cut-ransac'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/progressive-x/graph-cut-ransac'...
Submodule path 'third-party/DeepLSD/third_party/progressive-x/graph-cut-ransac': checked out 'fb628fa5f18ef5369c07291c709fde6f1cec23ac'
Submodule path 'third-party/DeepLSD/third_party/pytlbd': checked out 'b0c8cfcec43ff3267804e5cdd32c9697f4f2040d'
Submodule 'googletest' (https://github.com/google/googletest.git) registered for path 'third-party/DeepLSD/third_party/pytlbd/googletest'
Submodule 'pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/DeepLSD/third_party/pytlbd/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/pytlbd/googletest'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/pytlbd/pybind11'...
Submodule path 'third-party/DeepLSD/third_party/pytlbd/googletest': checked out 'e2239ee6043f73722e7aa812a459f54a28552929'
Submodule path 'third-party/DeepLSD/third_party/pytlbd/pybind11': checked out '4c7697dbe973ed01ae6fbec37d186ebd05982e1f'
Submodule path 'third-party/DeepLSD/third_party/pytlsd': checked out '21381ca4c5c8da297ef44ce07dda115075c5a648'
Submodule 'lib/pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/DeepLSD/third_party/pytlsd/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/DeepLSD/third_party/pytlsd/pybind11'...
Submodule path 'third-party/DeepLSD/third_party/pytlsd/pybind11': checked out '8de7772cc72daca8e947b79b83fea46214931604'
Submodule path 'third-party/GlueStick': checked out '40d71d5f4adc7f4fccae4cd7675a49daee3e873e'
Submodule path 'third-party/Hierarchical-Localization': checked out '61e0cd04dbc63d1beba1f8ed6c03e95937a76dab'
Submodule 'third_party/SuperGluePretrainedNetwork' (https://github.com/magicleap/SuperGluePretrainedNetwork.git) registered for path 'third-party/Hierarchical-Localization/third_party/SuperGluePretrainedNetwork'
Submodule 'third_party/d2net' (https://github.com/mihaidusmanu/d2-net.git) registered for path 'third-party/Hierarchical-Localization/third_party/d2net'
Submodule 'third_party/deep-image-retrieval' (https://github.com/naver/deep-image-retrieval.git) registered for path 'third-party/Hierarchical-Localization/third_party/deep-image-retrieval'
Submodule 'third_party/disk' (https://github.com/cvlab-epfl/disk.git) registered for path 'third-party/Hierarchical-Localization/third_party/disk'
Submodule 'third_party/r2d2' (https://github.com/naver/r2d2.git) registered for path 'third-party/Hierarchical-Localization/third_party/r2d2'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/SuperGluePretrainedNetwork'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/d2net'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/deep-image-retrieval'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/disk'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/r2d2'...
Submodule path 'third-party/Hierarchical-Localization/third_party/SuperGluePretrainedNetwork': checked out 'ddcf11f42e7e0732a0c4607648f9448ea8d73590'
Submodule path 'third-party/Hierarchical-Localization/third_party/d2net': checked out '2a4d88fbe84961a3a17c46adb6d16a94b87020c5'
Submodule path 'third-party/Hierarchical-Localization/third_party/deep-image-retrieval': checked out '278e7081364669c1e4e137a9ea6a0840ed0cf2bf'
Submodule path 'third-party/Hierarchical-Localization/third_party/disk': checked out 'eafa0ee80d26f86d6c838b78cea8ae4c9abd4b51'
Submodule 'submodules/torch-dimcheck' (https://github.com/jatentaki/torch-dimcheck.git) registered for path 'third-party/Hierarchical-Localization/third_party/disk/submodules/torch-dimcheck'
Submodule 'submodules/torch-localize' (https://github.com/jatentaki/torch-localize.git) registered for path 'third-party/Hierarchical-Localization/third_party/disk/submodules/torch-localize'
Submodule 'submodules/unets' (https://github.com/jatentaki/unets.git) registered for path 'third-party/Hierarchical-Localization/third_party/disk/submodules/unets'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/disk/submodules/torch-dimcheck'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/disk/submodules/torch-localize'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/Hierarchical-Localization/third_party/disk/submodules/unets'...
Submodule path 'third-party/Hierarchical-Localization/third_party/disk/submodules/torch-dimcheck': checked out '1b141ec38101500c59ae11ddb628e2fa3e40f18e'
Submodule path 'third-party/Hierarchical-Localization/third_party/disk/submodules/torch-localize': checked out 'f6dc5818ece911b6fed5bbdc3ce8aa2e60322116'
Submodule path 'third-party/Hierarchical-Localization/third_party/disk/submodules/unets': checked out 'af4d574c13b3f137115394e714522b815fc6a417'
Submodule path 'third-party/Hierarchical-Localization/third_party/r2d2': checked out 'd6777a9d6769448998e5abe11031ae05de28e49a'
Submodule path 'third-party/HighFive': checked out '5e77ac375928e339a8d43b39a122c28167a64dc1'
Submodule 'deps/hpc-coding-conventions' (https://github.com/BlueBrain/hpc-coding-conventions.git) registered for path 'third-party/HighFive/deps/hpc-coding-conventions'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/HighFive/deps/hpc-coding-conventions'...
Submodule path 'third-party/HighFive/deps/hpc-coding-conventions': checked out '609237f2774309ed08c92c92248e2f39de5b11d2'
Submodule path 'third-party/JLinkage': checked out '3787a84b3bf1cf7ec6bd7cf0f243bf53740a2129'
Submodule path 'third-party/RansacLib': checked out '3bfa5373ca723a3ca6d423fe1d6b024626ed348f'
Submodule 'ext/pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/RansacLib/ext/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/RansacLib/ext/pybind11'...
Submodule path 'third-party/RansacLib/ext/pybind11': checked out 'f067deb563d1073a7193b87d058fce37838ea5aa'
Submodule path 'third-party/TP-LSD': checked out '555805033e705ed6bfbf4d691528681bf4ae6706'
Submodule 'DCNv2' (git@github.com:jinfagang/DCNv2_latest.git) registered for path 'third-party/TP-LSD/tp_lsd/modeling/DCNv2'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/TP-LSD/tp_lsd/modeling/DCNv2'...
Enter passphrase for key '/home/mscherbina/.ssh/id_ed25519': 
Submodule path 'third-party/TP-LSD/tp_lsd/modeling/DCNv2': checked out '864c2850a780979f817c126b0e1a363a941ce07b'
Submodule path 'third-party/hawp': checked out '45bd43f704fc6252d88e06ba19d379b7a5753785'
Submodule path 'third-party/libigl': checked out 'e19a68cfa6141c72a7acb8021e85da1f919fffca'
Submodule path 'third-party/pybind11': checked out 'b3a43d137c6c9ecf271a2a3d51a51b2fd1c3e8f6'
Submodule path 'third-party/pytlbd': checked out 'b0c8cfcec43ff3267804e5cdd32c9697f4f2040d'
Submodule 'googletest' (https://github.com/google/googletest.git) registered for path 'third-party/pytlbd/googletest'
Submodule 'pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/pytlbd/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pytlbd/googletest'...
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pytlbd/pybind11'...
Submodule path 'third-party/pytlbd/googletest': checked out 'e2239ee6043f73722e7aa812a459f54a28552929'
Submodule path 'third-party/pytlbd/pybind11': checked out '4c7697dbe973ed01ae6fbec37d186ebd05982e1f'
Submodule path 'third-party/pytlsd': checked out '21381ca4c5c8da297ef44ce07dda115075c5a648'
Submodule 'lib/pybind11' (https://github.com/pybind/pybind11) registered for path 'third-party/pytlsd/pybind11'
Cloning into '/home/mscherbina/Documents/github_repos/cvg/frontend/packages/limap/third-party/pytlsd/pybind11'...
Submodule path 'third-party/pytlsd/pybind11': checked out '8de7772cc72daca8e947b79b83fea46214931604'
```